### PR TITLE
fix: identify 定位不准确

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,16 +292,7 @@ ClusterLayer.registerRenderer('canvas', class extends maptalks.renderer.VectorLa
         // if no clusters is hit, identify markers
         if (this._markersToDraw && this._markersToDraw[0]) {
             const point = map.coordinateToContainerPoint(coordinate);
-            let minDistance = point.distanceTo(map.coordinateToContainerPoint(this._markersToDraw[0]._coordinates));
-            let hitPoint = this._markersToDraw[0];
-            for (let i = 1; i < this._markersToDraw.length; i++) {
-                const dis = point.distanceTo(map.coordinateToContainerPoint(this._markersToDraw[i]._coordinates));
-                if (minDistance > dis) {
-                    minDistance = dis;
-                    hitPoint = this._markersToDraw[i];
-                }
-            }
-            return hitPoint;
+            return this.layer._hitGeos(this._markersToDraw, point, options);
         }
         return null;
     }


### PR DESCRIPTION
```js
        // if no clusters is hit, identify markers
        if (this._markersToDraw && this._markersToDraw[0]) {
            const point = map.coordinateToContainerPoint(coordinate);
            let minDistance = point.distanceTo(map.coordinateToContainerPoint(this._markersToDraw[0]._coordinates));
            let hitPoint = this._markersToDraw[0];
            for (let i = 1; i < this._markersToDraw.length; i++) {
                const dis = point.distanceTo(map.coordinateToContainerPoint(this._markersToDraw[i]._coordinates));
                if (minDistance > dis) {
                    minDistance = dis;
                    hitPoint = this._markersToDraw[i];
                }
            }
            return hitPoint;
        }
```
当前版本identify方法的判断逻辑有问题，无论点击地图的任何区域，都会返回与点击位置距离最小的maker。
fix #59 #33